### PR TITLE
Fix import in `LeanBoogie.lean`

### DIFF
--- a/LeanBoogie.lean
+++ b/LeanBoogie.lean
@@ -1,4 +1,4 @@
 -- This module serves as the root of the `LeanBoogie` library.
 -- Import modules here that should be built as part of the library.
 
-import LeanBoogie.BoogieDsl
+import LeanBoogie.Dsl


### PR DESCRIPTION
This makes `lake build` work, and I'm hoping that the CI will work with this, too.