### PR TITLE
Make more examples build

### DIFF
--- a/Examples.lean
+++ b/Examples.lean
@@ -1,3 +1,6 @@
+import LeanBoogie.Examples.AmAtChoice
 import LeanBoogie.Examples.Ffs
 import LeanBoogie.Examples.IterBlockyCongr
 import LeanBoogie.Examples.IterBlockyBounded
+import LeanBoogie.Examples.SimpleIter
+import LeanBoogie.Examples.Spec

--- a/LeanBoogie/Examples/AmAtChoice.lean
+++ b/LeanBoogie/Examples/AmAtChoice.lean
@@ -1,4 +1,4 @@
-import LeanBoogie.ITree
+import ITree
 import LeanBoogie.Effect.AmAtCh
 
 open LeanBoogie ITree

--- a/LeanBoogie/Examples/Spec.lean
+++ b/LeanBoogie/Examples/Spec.lean
@@ -2,6 +2,8 @@ import LeanBoogie.Effect.AmAtCh
 
 open ITree LeanBoogie
 
+namespace LeanBoogie.Examples.Spec
+
 def unsign (x : Int) : ITree Choice Int := do
   if <- choice Bool then
     return x
@@ -64,3 +66,5 @@ def divW : ITree0W Int := ⟨
   fun Post => Post spin ,
   sorry
 ⟩
+
+end LeanBoogie.Examples.Spec

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -9,3 +9,6 @@ lean_lib LeanBoogie where
   require ITree from git "https://github.com/boogie-org/lean-itrees.git" @ "59c895f4f70cd84ad6c8d6524a605eaaab26fe87"
   require auto from git "https://github.com/leanprover-community/lean-auto.git" @ "680d6d58ce2bb65d15e5711d93111b2e5b22cb1a" -- 4.12
   require Duper from git "https://github.com/leanprover-community/duper.git" @ "25c3ea88da2505158998eea07f40b07c0cdfe5ba"
+
+lean_exe Examples where
+  root := `Examples


### PR DESCRIPTION
This updates two examples to build, imports them from the top-level `Examples` modules, and adds a target for `Examples` to `lakefile.lean`.